### PR TITLE
Create lock_HassTurnOff and lock_HassTurnOn for fr-CA language

### DIFF
--- a/sentences/fr-CA/lock_HassTurnOff.yaml
+++ b/sentences/fr-CA/lock_HassTurnOff.yaml
@@ -1,0 +1,15 @@
+language: fr
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "débarre[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "débarre[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+        slots:
+          domain: "lock"
+        response: lock


### PR DESCRIPTION
Create lock_HassTurnOff and lock_HassTurnOn for fr-CA language. People from Quebec usually use the words "barrer" and "débarrer" which differ from the words used in france.